### PR TITLE
fix: applicant server connection update

### DIFF
--- a/backend/app/crud/applicant.py
+++ b/backend/app/crud/applicant.py
@@ -18,7 +18,7 @@ def clean_string(s: Optional[str]) -> Optional[str]:
 
 async def create_applicant(db: AsyncSession, applicant_in: ApplicantCreate) -> Applicant:
     new_applicant = Applicant(
-        email=applicant_in.email,
+        applicant_email=applicant_in.email,
         first_name=clean_string(applicant_in.first_name),
         last_name=clean_string(applicant_in.last_name),
         password=get_password_hash(applicant_in.password),

--- a/backend/app/crud/notification.py
+++ b/backend/app/crud/notification.py
@@ -5,10 +5,20 @@ from sqlalchemy.future import select
 from app.models.notification import Notification
 from app.schemas.notification import NotificationCreate
 from typing import List, Optional
+from datetime import datetime
 
 
 async def create_notification(session: AsyncSession, notification: NotificationCreate) -> Notification:
-    db_notification = Notification(**notification.dict())
+    notification_data = notification.dict()
+    
+    # Handle timezone-aware datetime
+    if 'created_at' in notification_data and notification_data['created_at'] is not None:
+        created_at = notification_data['created_at']
+        if hasattr(created_at, 'tzinfo') and created_at.tzinfo is not None:
+            # Convert timezone-aware to timezone-naive
+            notification_data['created_at'] = created_at.replace(tzinfo=None)
+    
+    db_notification = Notification(**notification_data)
     session.add(db_notification)
     await session.commit()
     await session.refresh(db_notification)

--- a/backend/app/models/applicant.py
+++ b/backend/app/models/applicant.py
@@ -1,5 +1,6 @@
-﻿from sqlalchemy import Integer, String, Text, Enum, JSON, ForeignKey, Boolean, Date
+﻿from sqlalchemy import Integer, String, Text, JSON, ForeignKey, Boolean, Date
 from sqlalchemy.orm import relationship, Mapped, mapped_column
+from sqlalchemy.dialects.postgresql import ENUM
 from app.models.base import Base
 from app.models.enums import MainFieldEnum, WorkSettingEnum, WorkTypeEnum
 from datetime import date
@@ -8,7 +9,7 @@ class Applicant(Base):
     __tablename__ = "Applicant"
 
     applicant_id: Mapped[int] = mapped_column(primary_key=True)
-    email: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    applicant_email: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     first_name: Mapped[str] = mapped_column(String, nullable=False)
     last_name: Mapped[str] = mapped_column(String, nullable=False)
     password: Mapped[str] = mapped_column(String, nullable=False)
@@ -18,9 +19,9 @@ class Applicant(Base):
     university: Mapped[str] = mapped_column(String, nullable=True)
     degree: Mapped[str] = mapped_column(String, nullable=True)
     year_graduated: Mapped[int] = mapped_column(Integer, nullable=True)
-    field: Mapped[MainFieldEnum] = mapped_column(Enum(MainFieldEnum), nullable=True)
-    preferred_worksetting: Mapped[WorkSettingEnum] = mapped_column(Enum(WorkSettingEnum), nullable=True)
-    preferred_worktype: Mapped[WorkTypeEnum] = mapped_column(Enum(WorkTypeEnum), nullable=True)
+    field: Mapped[MainFieldEnum] = mapped_column(ENUM('Software Development', 'Infrastructure & System', 'AI/ML', 'Data Science', 'Cybersecurity', 'UI/UX', name="main_field_enum"), nullable=True)
+    preferred_worksetting: Mapped[WorkSettingEnum] = mapped_column(ENUM('hybrid', 'remote', 'onsite', name="worksetting_enum"), nullable=True)
+    preferred_worktype: Mapped[WorkTypeEnum] = mapped_column(ENUM('part-time', 'fulltime', 'contractual', 'internship', name="worktype_enum"), nullable=True)
     applicant_profile_picture: Mapped[str] = mapped_column(Text, nullable=True)
     social_links: Mapped[dict] = mapped_column(JSON, nullable=True)
 

--- a/backend/app/models/interview.py
+++ b/backend/app/models/interview.py
@@ -1,5 +1,6 @@
-﻿from sqlalchemy import Integer, String, Date, Time, Enum, ForeignKey
-from sqlalchemy.orm import Mapped, mapped_column
+﻿from sqlalchemy import Integer, String, Date, Time, ForeignKey
+from sqlalchemy.dialects.postgresql import ENUM
+from sqlalchemy.orm import relationship, Mapped, mapped_column
 from app.models.base import Base
 from app.models.enums import InterviewTypeEnum, InterviewStatusEnum
 from datetime import date, time
@@ -10,9 +11,13 @@ class InterviewDetails(Base):
 
     applicant_id: Mapped[int] = mapped_column(ForeignKey("Applicant.applicant_id"), primary_key=True)
     job_id: Mapped[int] = mapped_column(ForeignKey("Job.job_id"), primary_key=True)
-    interview_type: Mapped[InterviewTypeEnum] = mapped_column(Enum(InterviewTypeEnum), nullable=True)
-    interview_date: Mapped[date] = mapped_column(nullable=True)
-    interview_time: Mapped[time] = mapped_column(nullable=True)
+    interview_type: Mapped[InterviewTypeEnum] = mapped_column(ENUM('onsite', 'phone_call', 'online', name="interview_type_enum"), nullable=False)
+    interview_date: Mapped[date] = mapped_column(Date, nullable=False)
+    interview_time: Mapped[time] = mapped_column(Time, nullable=False)
     remarks: Mapped[str] = mapped_column(String, nullable=True)
-    interview_status: Mapped[InterviewStatusEnum] = mapped_column(Enum(InterviewStatusEnum), nullable=True)
+    interview_status: Mapped[InterviewStatusEnum] = mapped_column(ENUM('cancelled', 'confirmed', name="interview_status_enum"), nullable=False)
+
+    # Add relationships if needed
+    # applicant = relationship("Applicant", back_populates="interviews")
+    # job = relationship("Job", back_populates="interviews")
 

--- a/backend/app/schemas/applicant.py
+++ b/backend/app/schemas/applicant.py
@@ -43,10 +43,25 @@ class ApplicantUpdate(BaseModel):
     social_links: Optional[Dict[str, str]] = None
 
 # For responses
-class ApplicantOut(ApplicantBase):
+class ApplicantOut(BaseModel):
     applicant_id: int
+    applicant_email: str
+    first_name: str
+    last_name: str
+    current_address: Optional[str] = None
+    contact_number: Optional[str] = None
+    telephone_number: Optional[str] = None
+    university: Optional[str] = None
+    degree: Optional[str] = None
+    year_graduated: Optional[int] = None
+    field: Optional[MainFieldEnum] = None
+    preferred_worksetting: Optional[WorkSettingEnum] = None
+    preferred_worktype: Optional[WorkTypeEnum] = None
+    applicant_profile_picture: Optional[str] = None
+    social_links: Optional[dict] = None
 
-    model_config = {"from_attributes": True}
+    class Config:
+        from_attributes = True  # For Pydantic v2, use from_attributes instead of orm_mode
 
 # Applicant Work Experience
 class ApplicantWorkExperienceBase(BaseModel):

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -12,8 +12,10 @@ class JobApplicationCreate(JobApplicationBase):
     applicant_id: int
     job_id: int
 
-class JobApplicationUpdate(JobApplicationBase):
-    pass
+class JobApplicationUpdate(BaseModel):
+    status: Optional[str] = None
+    remarks: Optional[str] = None
+    # Don't include created_at - it should never be updated
 
 class JobApplicationOut(JobApplicationBase):
     applicant_id: int


### PR DESCRIPTION
- Renamed email -> applicant_email (crud\applicant.py)
- changed timestamp -> timestamptz
- created_at timezones not changed during PUT
- ENUM direct input on models initialization
- interview table is now composite primary key (applicant_id + job_id)

table changes (models + schemas)
* applicant.py
* application.py
* notification.py
* interview.py